### PR TITLE
Update to Protocol 18.0.0 [fix #33]

### DIFF
--- a/birdbox/microsite/templates/microsite/partials/footer.html
+++ b/birdbox/microsite/templates/microsite/partials/footer.html
@@ -71,8 +71,8 @@
           {% comment %} {{social_link_group.title}} is available here, for future use {% endcomment %}
           {% for social_link in social_link_group.value.links %}
           <li>
-              <a class="{{social_link.icon}}" href="{{social_link.url}}">
-                <span>{{social_link.data_label}}</span>
+              <a class="{{social_link.icon}}" href="{{social_link.url}}"{% if social_link.rel %} rel='{{social_link.rel}}'{% endif %}>
+                  <span>{{social_link.data_label}}</span>
               </a>
           </li>
           {% endfor %}

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@babel/core": "^7.22.5",
         "@babel/preset-env": "^7.22.5",
-        "@mozilla-protocol/core": "^17.0.1",
+        "@mozilla-protocol/core": "^18.0.0",
         "babel-loader": "^9.1.2",
         "clean-webpack-plugin": "^4.0.0",
         "copy-webpack-plugin": "^11.0.0",
@@ -1760,9 +1760,9 @@
       "dev": true
     },
     "node_modules/@mozilla-protocol/core": {
-      "version": "17.0.1",
-      "resolved": "https://registry.npmjs.org/@mozilla-protocol/core/-/core-17.0.1.tgz",
-      "integrity": "sha512-xN6DNJ1P93lqrzhEHhx6J8HvIVpWDBLNOO4cqlHWH6HNPOoD/vsfygCwg6UJ+pkWBAwQLbS10xgB3Y2+kCP82Q=="
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/@mozilla-protocol/core/-/core-18.0.0.tgz",
+      "integrity": "sha512-jHZQxmr4Ogqg4avz5tznPvUNZvcFgddOPj+KhH14G9QzOUfbrfErdNtocRaa4H30U4vDbL5LiKmrWcF+RXNS3g=="
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -8517,9 +8517,9 @@
       "dev": true
     },
     "@mozilla-protocol/core": {
-      "version": "17.0.1",
-      "resolved": "https://registry.npmjs.org/@mozilla-protocol/core/-/core-17.0.1.tgz",
-      "integrity": "sha512-xN6DNJ1P93lqrzhEHhx6J8HvIVpWDBLNOO4cqlHWH6HNPOoD/vsfygCwg6UJ+pkWBAwQLbS10xgB3Y2+kCP82Q=="
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/@mozilla-protocol/core/-/core-18.0.0.tgz",
+      "integrity": "sha512-jHZQxmr4Ogqg4avz5tznPvUNZvcFgddOPj+KhH14G9QzOUfbrfErdNtocRaa4H30U4vDbL5LiKmrWcF+RXNS3g=="
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "@babel/core": "^7.22.5",
     "@babel/preset-env": "^7.22.5",
-    "@mozilla-protocol/core": "^17.0.1",
+    "@mozilla-protocol/core": "^18.0.0",
     "babel-loader": "^9.1.2",
     "clean-webpack-plugin": "^4.0.0",
     "copy-webpack-plugin": "^11.0.0",

--- a/src/css/birdbox-protocol-overrides.scss
+++ b/src/css/birdbox-protocol-overrides.scss
@@ -58,7 +58,8 @@ figure {
 
 .mzp-c-navigation {
    box-shadow: 0 0 1px 1px rgba(29, 17, 51, .04), 0 0 3px 2px rgba(9, 32, 77, .12), 0 0 2px -3px rgba(29, 17, 51, .12);
-    a.mzp-c-button {
+
+   a.mzp-c-button {
         @include hidden;
 
         @media #{$mq-md} {
@@ -77,4 +78,12 @@ figure {
         line-height: 1.1;
         text-decoration: none !important;
     }
+}
+
+.mzp-c-notification-bar {
+    margin-bottom: $spacing-lg;
+}
+
+.mzp-c-newsletter {
+    grid-gap: $spacing-xl;
 }

--- a/src/css/blog.scss
+++ b/src/css/blog.scss
@@ -3,14 +3,9 @@
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 // custom CSS for the Blog pages
-
-
 @import '~@mozilla-protocol/core/protocol/css/includes/lib';
-
 @import '~@mozilla-protocol/core/protocol/css/components/article';
-
 @import '~@mozilla-protocol/core/protocol/css/components/split';
-
 @import 'pre-protocol/pagination.scss';
 
 
@@ -29,7 +24,6 @@
     padding: 3px $spacing-sm;
     text-transform: uppercase;
 }
-
 
 .blogpost figure.header-image {
     margin-bottom: $spacing-lg;

--- a/src/css/protocol/components/article.scss
+++ b/src/css/protocol/components/article.scss
@@ -2,7 +2,4 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-$font-path: '/static/protocol/fonts';
-$image-path: '/static/protocol/img';
-
 @import '~@mozilla-protocol/core/protocol/css/components/article';

--- a/src/css/protocol/components/article.scss
+++ b/src/css/protocol/components/article.scss
@@ -2,4 +2,5 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' as * with ($image-path: '/static/protocol/img');
 @import '~@mozilla-protocol/core/protocol/css/components/article';

--- a/src/css/protocol/components/callout.scss
+++ b/src/css/protocol/components/callout.scss
@@ -2,7 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-@import '~@mozilla-protocol/core/protocol/css/includes/lib';
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' as * with ($image-path: '/static/protocol/img');
 @import '~@mozilla-protocol/core/protocol/css/components/call-out';
 
 .mzp-c-call-out-compact {

--- a/src/css/protocol/components/callout.scss
+++ b/src/css/protocol/components/callout.scss
@@ -2,9 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-$font-path: '/static/protocol/fonts';
-$image-path: '/static/protocol/img';
-
+@import '~@mozilla-protocol/core/protocol/css/includes/lib';
 @import '~@mozilla-protocol/core/protocol/css/components/call-out';
 
 .mzp-c-call-out-compact {

--- a/src/css/protocol/components/card.scss
+++ b/src/css/protocol/components/card.scss
@@ -2,5 +2,6 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' as * with ($image-path: '/static/protocol/img');
 @import '~@mozilla-protocol/core/protocol/css/templates/card-layout';
 @import '~@mozilla-protocol/core/protocol/css/components/card';

--- a/src/css/protocol/components/card.scss
+++ b/src/css/protocol/components/card.scss
@@ -2,8 +2,5 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-$font-path: '/static/protocol/fonts';
-$image-path: '/static/protocol/img';
-
 @import '~@mozilla-protocol/core/protocol/css/templates/card-layout';
 @import '~@mozilla-protocol/core/protocol/css/components/card';

--- a/src/css/protocol/components/footer.scss
+++ b/src/css/protocol/components/footer.scss
@@ -2,7 +2,5 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-$font-path: '/static/protocol/fonts';
-$image-path: '/static/protocol/img';
-
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' as * with ($image-path: '/static/protocol/img');
 @import '~@mozilla-protocol/core/protocol/css/components/footer';

--- a/src/css/protocol/components/footer.scss
+++ b/src/css/protocol/components/footer.scss
@@ -4,3 +4,10 @@
 
 @use '~@mozilla-protocol/core/protocol/css/includes/lib' as * with ($image-path: '/static/protocol/img');
 @import '~@mozilla-protocol/core/protocol/css/components/footer';
+
+.mzp-c-footer-links-social {
+    a.mastodon {
+        background-image: url("/static/protocol/img/icons/social/mastodon/white.svg");
+        background-size: 16px 16px;
+    }
+}

--- a/src/css/protocol/components/navigation.scss
+++ b/src/css/protocol/components/navigation.scss
@@ -2,9 +2,7 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-$font-path: '/static/protocol/fonts';
-$image-path: '/static/protocol/img';
-
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' as * with ($image-path: '/static/protocol/img');
 @import '~@mozilla-protocol/core/protocol/css/components/navigation';
 @import '~@mozilla-protocol/core/protocol/css/components/menu';
 @import '~@mozilla-protocol/core/protocol/css/components/menu-item';

--- a/src/css/protocol/components/newsletter.scss
+++ b/src/css/protocol/components/newsletter.scss
@@ -2,4 +2,5 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' as * with ($image-path: '/static/protocol/img');
 @import '~@mozilla-protocol/core/protocol/css/components/newsletter-form';

--- a/src/css/protocol/components/newsletter.scss
+++ b/src/css/protocol/components/newsletter.scss
@@ -2,7 +2,4 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-$font-path: '/static/protocol/fonts';
-$image-path: '/static/protocol/img';
-
 @import '~@mozilla-protocol/core/protocol/css/components/newsletter-form';

--- a/src/css/protocol/components/picto.scss
+++ b/src/css/protocol/components/picto.scss
@@ -2,7 +2,4 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-$font-path: '/static/protocol/fonts';
-$image-path: '/static/protocol/img';
-
 @import '~@mozilla-protocol/core/protocol/css/components/picto';

--- a/src/css/protocol/components/picto.scss
+++ b/src/css/protocol/components/picto.scss
@@ -2,4 +2,5 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' as * with ($image-path: '/static/protocol/img');
 @import '~@mozilla-protocol/core/protocol/css/components/picto';

--- a/src/css/protocol/components/split.scss
+++ b/src/css/protocol/components/split.scss
@@ -2,7 +2,4 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-$font-path: '/static/protocol/fonts';
-$image-path: '/static/protocol/img';
-
 @import '~@mozilla-protocol/core/protocol/css/components/split';

--- a/src/css/protocol/components/split.scss
+++ b/src/css/protocol/components/split.scss
@@ -2,4 +2,5 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' as * with ($image-path: '/static/protocol/img');
 @import '~@mozilla-protocol/core/protocol/css/components/split';

--- a/src/css/protocol/components/video.scss
+++ b/src/css/protocol/components/video.scss
@@ -2,7 +2,5 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-$font-path: '/static/protocol/fonts';
-$image-path: '/static/protocol/img';
-
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' as * with ($image-path: '/static/protocol/img');
 @import '~@mozilla-protocol/core/protocol/css/components/video';

--- a/src/css/protocol/firefox.scss
+++ b/src/css/protocol/firefox.scss
@@ -2,10 +2,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-$brand-theme: 'firefox';
-$type-scale: 'standard';
-$font-path: '/static/protocol/fonts';
-$image-path: '/static/protocol/img';
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' as * with ($brand-theme: 'firefox', $type-scale: 'standard', $font-path: '/static/protocol/fonts', $image-path: '/static/protocol/img');
+@use '~@mozilla-protocol/core/protocol/css/includes/themes';
 
 // These are general styles for elements/components that occur on every page.
 // Individual pages may include additional component styles as needed.
@@ -27,6 +25,7 @@ $image-path: '/static/protocol/img';
 // Global components
 @import '~@mozilla-protocol/core/protocol/css/components/button';
 @import '~@mozilla-protocol/core/protocol/css/components/notification-bar';
+@import '~@mozilla-protocol/core/protocol/css/components/forms/form';
 
 // Custom overrides for use in Birdbox
 @import './src/css/birdbox-protocol-overrides.scss'

--- a/src/css/protocol/layouts/columns.scss
+++ b/src/css/protocol/layouts/columns.scss
@@ -2,4 +2,5 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+@use '~@mozilla-protocol/core/protocol/css/includes/lib';
 @import '~@mozilla-protocol/core/protocol/css/templates/multi-column';

--- a/src/css/protocol/layouts/columns.scss
+++ b/src/css/protocol/layouts/columns.scss
@@ -2,7 +2,4 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-$font-path: '/static/protocol/fonts';
-$image-path: '/static/protocol/img';
-
 @import '~@mozilla-protocol/core/protocol/css/templates/multi-column';

--- a/src/css/protocol/mozilla.scss
+++ b/src/css/protocol/mozilla.scss
@@ -2,10 +2,8 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-$brand-theme: 'mozilla';
-$type-scale: 'standard';
-$font-path: '/static/protocol/fonts';
-$image-path: '/static/protocol/img';
+@use '~@mozilla-protocol/core/protocol/css/includes/lib' as * with ($brand-theme: 'mozilla', $type-scale: 'standard', $font-path: '/static/protocol/fonts', $image-path: '/static/protocol/img');
+@use '~@mozilla-protocol/core/protocol/css/includes/themes';
 
 // These are general styles for elements/components that occur on every page.
 // Individual pages may include additional component styles as needed.
@@ -27,6 +25,7 @@ $image-path: '/static/protocol/img';
 // Global components
 @import '~@mozilla-protocol/core/protocol/css/components/button';
 @import '~@mozilla-protocol/core/protocol/css/components/notification-bar';
+@import '~@mozilla-protocol/core/protocol/css/components/forms/form';
 
 // Custom overrides for use in Birdbox
 @import './src/css/birdbox-protocol-overrides.scss'


### PR DESCRIPTION
Update to Protocol 18.0.0 [fix #33]
Add bottom margin to notification bar [fix #34]
Add column gutter to newsletter [#38]

<s>My local install isn't getting images from Protocol but I'm not sure where that's failing, if it's a problem in webpack during the build or a problem in the CSS with image paths, or something else... if we can reproduce it while reviewing this PR maybe we can debug and fix it here before merging. But if it's something just on my setup then maybe this is fine?</s>

I think I solved it. The components that feature images in their CSS need to have the image path defined before they're imported.