### PR TITLE
Add simple Google Tag analytics support

### DIFF
--- a/birdbox/birdbox/settings/base.py
+++ b/birdbox/birdbox/settings/base.py
@@ -97,6 +97,7 @@ TEMPLATES = [
                 "django.contrib.auth.context_processors.auth",
                 "django.contrib.messages.context_processors.messages",
                 "wagtail.contrib.settings.context_processors.settings",
+                "microsite.context_processors.google_tag",
             ],
         },
     },
@@ -375,3 +376,6 @@ BLOG_PAGINATION_PAGE_SIZE = config(
     default="6",
     parser=int,
 )
+
+# For analytics
+GOOGLE_TAG_ID = config("GOOGLE_TAG_ID", default="", parser=str)

--- a/birdbox/birdbox/templates/base.html
+++ b/birdbox/birdbox/templates/base.html
@@ -48,7 +48,8 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
         {% block extra_head %}{% endblock extra_head %}
 
     </head>
-
+    {% block analytics %}
+    {% endblock analytics %}
     <body class="{% block body_class %}{% endblock %}">
         {% wagtailuserbar %}
 

--- a/birdbox/microsite/context_processors.py
+++ b/birdbox/microsite/context_processors.py
@@ -1,0 +1,9 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+from django.conf import settings
+
+
+def google_tag(request):
+    return {"GOOGLE_TAG_ID": settings.GOOGLE_TAG_ID}

--- a/birdbox/microsite/templates/microsite/base.html
+++ b/birdbox/microsite/templates/microsite/base.html
@@ -1,6 +1,18 @@
 {% extends 'base.html' %}
 {% load microsite_tags static %}
 
+{% block analytics %}
+{% if GOOGLE_TAG_ID %}
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id={{GOOGLE_TAG_ID}}"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', '{{GOOGLE_TAG_ID}}');
+</script>
+{% endif %}
+{% endblock analytics %}
 
 {% block global_stylesheets %}
   {% global_css_tag %}

--- a/birdbox/microsite/tests/test_context_processors.py
+++ b/birdbox/microsite/tests/test_context_processors.py
@@ -1,0 +1,16 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+from unittest import mock
+
+from django.test import override_settings
+
+from microsite import context_processors
+
+
+@override_settings(GOOGLE_TAG_ID="ThisIsATest")
+def test_google_tag():
+    assert context_processors.google_tag(mock.Mock()) == {
+        "GOOGLE_TAG_ID": "ThisIsATest",
+    }

--- a/src/js/newsletter/newsletter.es6
+++ b/src/js/newsletter/newsletter.es6
@@ -151,7 +151,7 @@ const NewsletterForm = {
     const email = form.querySelector('input[type="email"]').value;
 
     e.preventDefault();
-    e.stopPropagation();
+    // e.stopPropagation();  // Disabled to allow analytics to capture form event
 
     // Disable form fields until POST has completed.
     FormUtils.disableFormFields(form);


### PR DESCRIPTION
Same markup as on future.m.o

No need to test drive this one - here's a screenshot 

<img width="753" alt="Screenshot 2023-09-15 at 23 24 32" src="https://github.com/mozmeao/birdbox/assets/101457/f9e656dc-50de-4a6d-a6b7-590ce920ef55">

Resolves #39 