### PR TITLE
Add rate limiting

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -19,6 +19,16 @@ jobs:
         run: |
           pip install -r requirements/production.txt
           pip install -r requirements/test.txt
+      - name: Set up Node
+        uses: actions/setup-node@v3.8.1
+        with:
+          node-version: 18
+      - name: Install js dependencies and build assets
+        run: |
+          npm ci
+          npm run build
+      - name: Collect staticfiles
+        run: python birdbox/manage.py collectstatic
       - name: Run tests
         run: >-
           DJANGO_SETTINGS_MODULE=birdbox.settings.test

--- a/birdbox/birdbox/settings/base.py
+++ b/birdbox/birdbox/settings/base.py
@@ -75,6 +75,10 @@ MIDDLEWARE = [
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "django.middleware.security.SecurityMiddleware",
     "whitenoise.middleware.WhiteNoiseMiddleware",
+    # set_remote_addr_from_forwarded_for must come before rate_limiter
+    "common.middleware.set_remote_addr_from_forwarded_for",
+    "common.middleware.rate_limiter",
+    "django_ratelimit.middleware.RatelimitMiddleware",
     "wagtail.contrib.redirects.middleware.RedirectMiddleware",
 ]
 
@@ -352,6 +356,25 @@ if SENTRY_DSN:
         integrations=[DjangoIntegration()],
     )
 
+# Rate limiting using django-ratelimit
+
+RATELIMIT_ENABLE = config(
+    "RATELIMIT_ENABLE",
+    default="True",
+    parser=bool,
+)
+RATELIMIT_USE_CACHE = config(
+    "RATELIMIT_USE_CACHE",
+    default="default",
+    parser=str,
+)
+RATELIMIT_VIEW = "common.views.rate_limited"
+RATELIMIT_DEFAULT_LIMIT = config(
+    "RATELIMIT_DEFAULT_LIMIT",
+    default="25/m",
+    parser=str,
+)
+
 
 # Mozillaverse settings
 
@@ -390,6 +413,8 @@ BLOG_PAGINATION_PAGE_SIZE = config(
 # For analytics
 GOOGLE_TAG_ID = config("GOOGLE_TAG_ID", default="", parser=str)
 
+
+# For Mozilla Innovations contact form ONLY
 CONTACT_FORM_RECIPIENT_EMAIL = {
     "default": config(
         "CONTACT_FORM_RECIPIENT_EMAIL__DEFAULT",

--- a/birdbox/birdbox/settings/dev.py
+++ b/birdbox/birdbox/settings/dev.py
@@ -5,7 +5,7 @@
 from .base import *
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+DEBUG = config("DEBUG", default="True", parser=bool)
 
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = "django-insecure-$+g4fy7sgdkat&(^#)rppzy(1gklmpahro@9d@!40i_j*al6%m"

--- a/birdbox/birdbox/templates/403.html
+++ b/birdbox/birdbox/templates/403.html
@@ -1,0 +1,18 @@
+{% extends "microsite/base.html" %}
+
+{% block title %}Access Denied{% endblock %}
+
+{% block body_class %}template-403{% endblock %}
+
+{% block content %}
+<div class="mzp-l-content mzp-t-content-lg">
+  <h1>Access denied</h1>
+  <p>
+    You tried to access a page that is off limits.
+  </p>
+  <p>
+    <a href="/">Head back to the home page.</a>
+  </p>
+</div>
+{% endblock %}
+

--- a/birdbox/birdbox/templates/429.html
+++ b/birdbox/birdbox/templates/429.html
@@ -1,0 +1,19 @@
+{% extends "microsite/base.html" %}
+
+{% block title %}Rate limited{% endblock %}
+
+{% block body_class %}template-429{% endblock %}
+
+{% block content %}
+<div class="mzp-l-content mzp-t-content-lg">
+  <h1>Please, take it easy</h1>
+  <h2>Your request has been denied</h2>
+  <p>
+    We've noticed your IP address has been making too many requests in a short space of time.
+  </p>
+  <p>
+    You can try again in about a minute.
+  </p>
+</div>
+{% endblock %}
+

--- a/birdbox/common/middleware.py
+++ b/birdbox/common/middleware.py
@@ -1,0 +1,85 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+"""Custom middleware for Birdbox"""
+
+from django.conf import settings
+
+from django_ratelimit import ALL
+from django_ratelimit.core import is_ratelimited
+from django_ratelimit.exceptions import Ratelimited
+
+
+def rate_limiter(get_response):
+    """Enforces rate-limiting on all views.
+
+    Custom wrapper for django-ratelimit so we can use it with Wagtail.
+
+    Why are we rate-limiting ALL views and not just those that the CDN won't
+    be cacheing? Here's the logic:
+
+    * Most production traffic spikes will be handled by the CDN.
+    * However, querystrings on requests (either deliberately if/when we add search,
+    or via abuse) can lead to CDN cache misses
+    * We can't decorate the main Wagtail page-serving view with django-ratelimit, but
+    we can use middleware to do perform rate-limiting checks, using django-ratelimit's
+    core helpers
+    * However, django-ratelimit's API/helpers need a request object because they
+    rate-limit based on a view func, not a path from the URL, so we can't easily target
+    specific Wagtail-served pages for rate limiting
+
+    With all that in mind, including the fact the CDN will cache pages, we rate-limit
+    ALL the pages served by the site. In the wild, once the CDN is warm, we should
+    only be rate-limiting abuse.
+
+    The limit set will be one which should not impair real-world content curation via
+    /admin/ either.
+
+    """
+
+    def middleware(request):
+        # Set an arbitrary catch-all group name, because we need to provide
+        # a group because we don't have the view func available here.
+        group = "all_requests"
+
+        old_limited = getattr(request, "limited", False)
+        ratelimited = is_ratelimited(
+            request=request,
+            group=group,
+            key="ip",
+            rate=settings.RATELIMIT_DEFAULT_LIMIT,
+            increment=True,
+            method=ALL,  # ie include GET, not just ratelimit.UNSAFE methods
+        )
+        request.limited = ratelimited or old_limited
+        if ratelimited:
+            raise Ratelimited()
+
+        response = get_response(request)
+        return response
+
+    return middleware
+
+
+def set_remote_addr_from_forwarded_for(get_response):
+    """
+    Middleware that sets REMOTE_ADDR based on HTTP_X_FORWARDED_FOR, if the
+    latter is set. This is useful if you're sitting behind a reverse proxy
+
+    TODO: consider switching to https://pypi.org/project/django-xff/
+    """
+
+    def middleware(request):
+        forwarded_for = request.META.get("HTTP_X_FORWARDED_FOR")
+        if forwarded_for:
+            # HTTP_X_FORWARDED_FOR can be a comma-separated list of IPs.
+            # The client's claimed IP will be the first in the list, as CDN etc
+            # append to the end.
+            forwarded_for = forwarded_for.split(",")[0].strip()
+            request.META["REMOTE_ADDR"] = forwarded_for
+
+        response = get_response(request)
+        return response
+
+    return middleware

--- a/birdbox/common/tests/test_middleware.py
+++ b/birdbox/common/tests/test_middleware.py
@@ -1,0 +1,120 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+from unittest import mock
+
+from django.conf import settings
+from django.core.cache import cache
+from django.test import RequestFactory, TestCase, override_settings
+
+from django_ratelimit.exceptions import Ratelimited
+
+from common.middleware import rate_limiter, set_remote_addr_from_forwarded_for
+
+
+@override_settings(RATELIMIT_ENABLE=True, RATELIMIT_DEFAULT_LIMIT="2/m")
+class RateLimiterMiddlewareTests(TestCase):
+    def tearDown(self):
+        cache.clear()
+
+    def test_rate_limiter_middleware_is_enabled(self):
+        for expected_middleware in [
+            "common.middleware.rate_limiter",
+            "django_ratelimit.middleware.RatelimitMiddleware",
+        ]:
+            assert expected_middleware in settings.MIDDLEWARE
+
+    def test_rate_limiter__works_for_all_http_methods(self):
+        factory = RequestFactory()
+
+        for method in ["get", "post", "put", "delete", "head", "options"]:
+            with self.subTest(label=method):
+                # django-ratelimit uses the default cache. Invalidating it between
+                # attempts means subtests will not interfere with each other
+                cache.clear()
+
+                mock_get_response = mock.Mock(name="get_response")
+                fake_request = getattr(factory, method)("/", REMOTE_ADDR="127.0.0.1")
+                middleware_func = rate_limiter(mock_get_response)
+
+                # First time, no problem
+                middleware_func(fake_request)
+                assert mock_get_response.call_count == 1
+
+                # Second time, no problem
+                middleware_func(fake_request)
+                assert mock_get_response.call_count == 2
+
+                # Third time: rate-limited problem
+                with self.assertRaises(Ratelimited):
+                    middleware_func(fake_request)
+                assert mock_get_response.call_count == 2  # ie, didn't get called again
+
+    @override_settings(RATELIMIT_DEFAULT_LIMIT="3/m")  # 3 per min max
+    def test_rate_limiter__definitely_separates_by_ip(self):
+        factory = RequestFactory()
+
+        mock_get_response = mock.Mock(name="get_response")
+        middleware_func = rate_limiter(mock_get_response)
+
+        # Four calls from different IPs: all fine
+        cache.clear()  # reset any previous rate limiting
+        for i, ip in enumerate(["127.0.0.1", "127.0.0.2", "127.0.0.3", "127.0.0.4"]):
+            fake_request = factory.get("/", REMOTE_ADDR=ip)
+            middleware_func(fake_request)
+            assert mock_get_response.call_count == 1 + i
+
+        # Four calls from SAME IP: fourth will be limited
+        cache.clear()  # reset any previous rate limiting
+
+        assert fake_request.META["REMOTE_ADDR"] == "127.0.0.4"
+
+        middleware_func(fake_request)
+        middleware_func(fake_request)
+        middleware_func(fake_request)
+        with self.assertRaises(Ratelimited):
+            middleware_func(fake_request)
+
+
+class RemoteAddressMiddlewareTests(TestCase):
+    def test_set_remote_addr_from_forwarded_for_middleware_is_enabled(self):
+        assert "common.middleware.set_remote_addr_from_forwarded_for" in settings.MIDDLEWARE
+
+    def test_set_remote_addr_from_forwarded_for_middleware(self):
+        remote_addr = "172.24.24.24"
+        cases = [
+            {
+                "x_forwarded_for_string": "172.31.255.255",
+                "expected_ip": "172.31.255.255",
+            },
+            {
+                "x_forwarded_for_string": "172.31.255.255, 172.16.1.1",
+                "expected_ip": "172.31.255.255",
+            },
+            {
+                "x_forwarded_for_string": "172.31.255.255, 172.16.1.1, 172.16.128.128",
+                "expected_ip": "172.31.255.255",
+            },
+            {"x_forwarded_for_string": "", "expected_ip": remote_addr},
+            {"x_forwarded_for_string": None, "expected_ip": remote_addr},
+        ]
+
+        factory = RequestFactory()
+
+        mock_get_response = mock.Mock(name="get_response")
+        middleware_func = set_remote_addr_from_forwarded_for(mock_get_response)
+
+        for case in cases:
+            mock_get_response.reset_mock()
+            with self.subTest(label=case):
+                xff = case["x_forwarded_for_string"]
+                if xff is None:
+                    kwargs = dict(REMOTE_ADDR=remote_addr)
+                else:
+                    kwargs = dict(REMOTE_ADDR=remote_addr, HTTP_X_FORWARDED_FOR=xff)
+                fake_request = factory.get("/", **kwargs)
+                middleware_func(fake_request)
+
+                updated_request = mock_get_response.call_args_list[0][0][0]
+                self.assertEqual(updated_request.META["REMOTE_ADDR"], case["expected_ip"])

--- a/birdbox/common/tests/test_views.py
+++ b/birdbox/common/tests/test_views.py
@@ -1,0 +1,27 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+from django.urls import path, reverse
+
+import pytest
+from django_ratelimit.exceptions import Ratelimited
+
+from common.views import rate_limited
+
+# Make the rate_limited view available to this test only without needing DEBUG=True.
+urlpatterns = [
+    path(
+        r"test-rate-limited/",
+        rate_limited,
+        {"exception": Ratelimited()},
+        name="test-rl-view",
+    )
+]
+
+
+@pytest.mark.urls(__name__)
+@pytest.mark.django_db
+def test_rate_limited__does_not_get_cached_at_cdn(client):
+    resp = client.get(reverse("test-rl-view"))
+    assert resp["Cache-Control"] == "max-age=0, no-cache, no-store, must-revalidate, private"

--- a/birdbox/common/views.py
+++ b/birdbox/common/views.py
@@ -3,6 +3,7 @@
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
 from django.shortcuts import render
+from django.views.decorators.cache import never_cache
 
 
 def server_error_view(request, template_name="500.html"):
@@ -13,3 +14,11 @@ def server_error_view(request, template_name="500.html"):
 def page_not_found_view(request, exception=None, template_name="404.html"):
     """404 error handler that runs context processors."""
     return render(request, template_name, status=404)
+
+
+@never_cache
+def rate_limited(request, exception):
+    """Render a rate-limited exception page"""
+    response = render(request, "429.html", status=429)
+    response["Retry-After"] = "60"
+    return response

--- a/justfile
+++ b/justfile
@@ -59,6 +59,7 @@ manage-py *ARGS:
     python birdbox/manage.py {{ARGS}}
 
 test *ARGS:
+    DEBUG=False \
     DJANGO_SETTINGS_MODULE=birdbox.settings.test \
     BASKET_NEWSLETTER_DATA_DO_SYNC=false \
         pytest birdbox {{ARGS}} \

--- a/requirements/production.in
+++ b/requirements/production.in
@@ -3,6 +3,7 @@ dj-database-url==2.1.0
 django-mozilla-product-details>=1.0.3
 django-storages[google]==1.14
 Django>=4.2.5
+django-ratelimit==4.1.0
 django-redis==5.3.0
 django-jsonview==2.0.0
 everett>=3.2.0

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -148,6 +148,10 @@ django-permissionedforms==0.1 \
     --hash=sha256:4340bb20c4477fffb13b4cc5cccf9f1b1010b64f79956c291c72d2ad2ed243f8 \
     --hash=sha256:d341a961a27cc77fde8cc42141c6ab55cc1f0cb886963cc2d6967b9674fa47d6
     # via wagtail
+django-ratelimit==4.1.0 \
+    --hash=sha256:555943b283045b917ad59f196829530d63be2a39adb72788d985b90c81ba808b \
+    --hash=sha256:d047a31cf94d83ef1465d7543ca66c6fc16695559b5f8d814d1b51df15110b92
+    # via -r requirements/production.in
 django-redis==5.3.0 \
     --hash=sha256:2d8660d39f586c41c9907d5395693c477434141690fd7eca9d32376af00b0aac \
     --hash=sha256:8bc5793ec06b28ea802aad85ec437e7646511d4e571e07ccad19cfed8b9ddd44


### PR DESCRIPTION
This changeset adds rate limiting to the project in a way that is compatible with Wagtail. 

Because the core CMS-based page-serving happens via a single view, we cannot just use the decorators from `django-ratelimit` as we do elsewhere in the org. Instead we have custom middleware that uses the core helpers from the `django-ratelimit` package to do the work.

This changeset also adds a 403 template as well as a 429 one for ratelimited responses.

<img width="1633" alt="Screenshot 2023-09-27 at 12 44 21" src="https://github.com/mozmeao/birdbox/assets/101457/6db01af8-215c-4158-95a8-bf9e8ff77795">
<img width="1533" alt="Screenshot 2023-09-27 at 14 55 21" src="https://github.com/mozmeao/birdbox/assets/101457/095c3930-42e5-4a56-b206-9a1d58509b5e">

Resolves #85 
