### PR TITLE
Remove default storage check done by django-watchman

### DIFF
--- a/birdbox/birdbox/settings/base.py
+++ b/birdbox/birdbox/settings/base.py
@@ -388,6 +388,12 @@ RATELIMIT_DEFAULT_LIMIT = config(
     parser=str,
 )
 
+# django-watchman
+WATCHMAN_DISABLE_APM = True
+WATCHMAN_CHECKS = (
+    "watchman.checks.caches",
+    "watchman.checks.databases",
+)
 
 # Authentication with Mozilla OpenID Connect / Auth0
 


### PR DESCRIPTION
This was causing 500s for the readiness probe route on k8s, and we don't use it with Nucleus either. Removing for now and will circle back to see if we can safely re-add it later