### PR TITLE
Add config that sets SECURE_PROXY_SSL_HEADER to True where needed

### DIFF
--- a/birdbox/.env-example
+++ b/birdbox/.env-example
@@ -1,3 +1,6 @@
+DEBUG=False
+DISABLE_SSL=True
+
 # Change to True if you want to use SSO locally, else you'll use username+password auth
 USE_SSO_AUTH=False
 

--- a/birdbox/birdbox/settings/base.py
+++ b/birdbox/birdbox/settings/base.py
@@ -395,6 +395,17 @@ WATCHMAN_CHECKS = (
     "watchman.checks.databases",
 )
 
+# SSL config. Note that SECURE_PROXY_SSL_HEADER has a bearing on SSO redirect URIs
+DISABLE_SSL = config("DISABLE_SSL", default=str(DEBUG), parser=bool)  # so default: "False"
+SECURE_SSL_REDIRECT = config("SECURE_SSL_REDIRECT", default=str(not DISABLE_SSL), parser=bool)  # so default: "True"
+if config("USE_SECURE_PROXY_HEADER", default=str(SECURE_SSL_REDIRECT), parser=bool):
+    SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
+
+SECURE_REDIRECT_EXEMPT = [
+    r"^healthz/$",
+    r"^readiness/$",
+]
+
 # Authentication with Mozilla OpenID Connect / Auth0
 
 LOGIN_ERROR_URL = "/admin/"

--- a/birdbox/birdbox/settings/test.py
+++ b/birdbox/birdbox/settings/test.py
@@ -5,3 +5,5 @@
 from .development import *
 
 DEBUG = False
+DISABLE_SSL = True
+SECURE_SSL_REDIRECT = False

--- a/docker/envfiles/local.env.example
+++ b/docker/envfiles/local.env.example
@@ -1,3 +1,6 @@
+DEBUG=False
+DISABLE_SSL=True
+
 EMAIL_BACKEND="django.core.mail.backends.console.EmailBackend"
 
 # If you want to use Google Cloud Storage locally, you'll need to set these

--- a/justfile
+++ b/justfile
@@ -63,7 +63,6 @@ manage-py *ARGS:
     python birdbox/manage.py {{ARGS}}
 
 test *ARGS:
-    DEBUG=False \
     DJANGO_SETTINGS_MODULE=birdbox.settings.test \
     BASKET_NEWSLETTER_DATA_DO_SYNC=false \
         pytest birdbox {{ARGS}} \


### PR DESCRIPTION
… so tht we get HTTPS-based URIs generated by Django. Currently, getting http:// URLs is preventing SSO auth because the redirect_uri does not match

This is doing (part of) what we do with Nucleus, and may be enough. If not, we can also copy the custom WSGI.py approach in Nucleus, too

https://github.com/mozilla/nucleus/blob/e4d7065dc28e964fd34a276f30b2f32cc54ffc92/nucleus/settings.py#L113C3-L119