### PR TITLE
Add a robots.txt response 

### DIFF
--- a/birdbox/birdbox/settings/base.py
+++ b/birdbox/birdbox/settings/base.py
@@ -268,8 +268,14 @@ WAGTAILSEARCH_BACKENDS = {
 # e.g. in notification emails. Don't include '/admin' or a trailing slash
 WAGTAILADMIN_BASE_URL = config(
     "WAGTAILADMIN_BASE_URL",
-    default="http://birdbox.mozilla.com",
+    default="http://future.mozilla.org",
 )
+
+BASE_SITE_URL = config(
+    "BASE_SITE_URL",
+    default=WAGTAILADMIN_BASE_URL,
+)
+
 
 WAGTAILEMBEDS_FINDERS = [
     {
@@ -319,6 +325,10 @@ RICHTEXT_FEATURES__ARTICLE = RICHTEXT_FEATURES__FULL
 RICHTEXT_FEATURES__BLOGPAGE = RICHTEXT_FEATURES__FULL
 RICHTEXT_FEATURES__BIO = RICHTEXT_FEATURES__SIMPLE
 RICHTEXT_FEATURES__DETAIL = RICHTEXT_FEATURES__SIMPLE
+
+# Robots.txt - also see production.py for where we may allow it to be rendered
+
+ENGAGE_ROBOTS = config("ENGAGE_ROBOTS", parser=bool, default="False")
 
 # Logging
 

--- a/birdbox/birdbox/settings/prod.py
+++ b/birdbox/birdbox/settings/prod.py
@@ -12,3 +12,9 @@ DEBUG = False
 CSRF_TRUSTED_ORIGINS = config("CSRF_TRUSTED_ORIGINS", parser=ListOf(str))
 ALLOWED_HOSTS = config("ALLOWED_HOSTS", parser=ListOf(str))
 SECRET_KEY = config("SECRET_KEY", parser=str)
+
+ENGAGE_ROBOTS = config(
+    "ENGAGE_ROBOTS",
+    parser=bool,
+    default=BASE_SITE_URL in ALLOWED_HOSTS,
+)

--- a/birdbox/birdbox/urls.py
+++ b/birdbox/birdbox/urls.py
@@ -4,7 +4,7 @@
 
 from django.conf import settings
 from django.contrib import admin
-from django.http import HttpResponseForbidden
+from django.http import HttpResponse, HttpResponseForbidden
 from django.urls import include, path
 from django.utils.module_loading import import_string
 from django.views.defaults import permission_denied
@@ -40,6 +40,13 @@ urlpatterns = [
     path("healthz/", watchman_views.ping, name="watchman.ping"),
     path("readiness/", watchman_views.status, name="watchman.status"),
     path("", include(microsite_urls)),
+    path(
+        "robots.txt",
+        lambda r: HttpResponse(
+            f"User-agent: *\n{'Allow' if settings.ENGAGE_ROBOTS else 'Disallow'}: /",
+            content_type="text/plain",
+        ),
+    ),
     # Disabled until we need Search
     # path("search/", search_views.search, name="search"),
 ]

--- a/birdbox/common/tests/test_views.py
+++ b/birdbox/common/tests/test_views.py
@@ -2,6 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+from django.test import override_settings
 from django.urls import path, reverse
 
 import pytest
@@ -25,3 +26,18 @@ urlpatterns = [
 def test_rate_limited__does_not_get_cached_at_cdn(client):
     resp = client.get(reverse("test-rl-view"))
     assert resp["Cache-Control"] == "max-age=0, no-cache, no-store, must-revalidate, private"
+
+
+@pytest.mark.parametrize(
+    "engage_robots,expected_content",
+    (
+        (True, b"User-agent: *\nAllow: /"),
+        (False, b"User-agent: *\nDisallow: /"),
+    ),
+)
+@pytest.mark.django_db
+@pytest.mark.urls("birdbox.urls")
+def test_robots_txt(client, engage_robots, expected_content):
+    with override_settings(ENGAGE_ROBOTS=engage_robots):
+        resp = client.get("/robots.txt")
+        assert resp.content == expected_content


### PR DESCRIPTION
…that only allows spidering if it's explicitly enabled or we're definitely on the production domain

The lambda-based approach came from Nucleus :)