### PR TITLE
Future mo landing page snags

### DIFF
--- a/birdbox/microsite/models.py
+++ b/birdbox/microsite/models.py
@@ -69,7 +69,7 @@ class ProtocolLayout(TextChoices):
 @method_decorator(never_cache, name="serve_password_required_response")
 class CacheAwareAbstractBasePage(Page):
     """
-    My default, Wagtail is unopinionated about cache-control headers,
+    By default, Wagtail is unopinionated about cache-control headers,
     so we need to be sure that pages with restrictions are not cached
     anywhere in the chain.
 

--- a/birdbox/microsite/templates/microsite/blocks/column.html
+++ b/birdbox/microsite/templates/microsite/blocks/column.html
@@ -2,14 +2,15 @@
 
 {% load wagtailcore_tags microsite_tags %}
 
-{% if block.value.title %}
-<div class="mzp-l-content {{block.value.theme}}">
-  <h2>{{block.value.title}}</h2>
-</div>
-{% endif %}
-<div class="{{block.value.column_layout}} {{block.value.theme}}">
-
-  {% for block in block.value.content %}
-    {% include_block block %}
-  {% endfor %}
+<div class="bb-column-block {{block.value.theme}}">
+  {% if block.value.title %}
+  <div class="mzp-l-content">
+    <h2>{{block.value.title}}</h2>
+  </div>
+  {% endif %}
+  <div class="{{block.value.column_layout}} {{block.value.theme}}">
+    {% for block in block.value.content %}
+      {% include_block block %}
+    {% endfor %}
+  </div>
 </div>

--- a/birdbox/microsite/templates/microsite/blocks/hero.html
+++ b/birdbox/microsite/templates/microsite/blocks/hero.html
@@ -40,7 +40,7 @@
         background-image: url('{{bg_image.url}}')
   {% endif %}"
 >
-  <div class="{% get_layout_class_from_page %}">
+  <div class="mzp-l-content">
       <div class="hero-text-wrapper">
           <h1>{{block.value.main_heading}}</h1>
         {% if block.value.subheading %}

--- a/birdbox/microsite/templates/microsite/blocks/section_heading.html
+++ b/birdbox/microsite/templates/microsite/blocks/section_heading.html
@@ -1,5 +1,7 @@
 {# https://protocol.mozilla.org/components/detail/section-heading.html #}
 
-<{{block.value.heading_level}} class="mzp-c-section-heading {{block.value.alignment}} {{block.value.heading_size}}">
+{% load microsite_tags %}
+
+<{{block.value.heading_level}} class="mzp-c-section-heading {{block.value.alignment}} {{block.value.heading_size}} {% get_layout_modifier_from_page %}">
   {{block.value.text}}
 </{{block.value.heading_level}}>

--- a/birdbox/microsite/templatetags/microsite_tags.py
+++ b/birdbox/microsite/templatetags/microsite_tags.py
@@ -92,6 +92,16 @@ def get_layout_class_from_page(context) -> str:
     return ""
 
 
+@register.simple_tag(takes_context=True)
+def get_layout_modifier_from_page(context) -> str:
+    # Generates a modifier class from the page layout class
+    # - eg turns "mzp-l-content mzp-t-content-md" into "mzp-u-modifier-md"
+    page = context.get("page")
+    if page:
+        return page.specific.page_layout.replace("mzp-l-content ", "").replace("mzp-t-content", "mzp-u-modifier")
+    return ""
+
+
 def _get_language_name_for_locale(locale_code):
     adjusted_locale_code = {
         "en": "en-US",

--- a/src/css/hero.scss
+++ b/src/css/hero.scss
@@ -15,12 +15,17 @@
 
     .hero-text-wrapper {
         @media #{$mq-md} {
-            max-width: 55%;
+            max-width: 45%;
+        }
+
+        h1 {
+            @include text-title-xs;
+            font-weight: normal;
+            text-transform: uppercase;
         }
 
         h2 {
-            @include text-title-sm;
-            font-weight: normal;
+            @include text-title-lg;
         }
     }
 }

--- a/src/css/protocol/components/section-heading.scss
+++ b/src/css/protocol/components/section-heading.scss
@@ -18,6 +18,22 @@
         padding: $layout-lg 80px;
     }
 
+    &.mzp-u-modifier-xl {
+        max-width: $content-xl;
+    }
+
+    &.mzp-u-modifier-lg {
+        max-width: $content-lg;
+    }
+
+    &.mzp-u-modifier-md {
+        max-width: $content-md;
+    }
+
+    &.mzp-u-modifier-sm {
+        max-width: $content-sm;
+    }
+
     &.t-align-center {
         max-width: $content-lg;
         text-align: center;

--- a/src/css/protocol/layouts/columns.scss
+++ b/src/css/protocol/layouts/columns.scss
@@ -2,5 +2,16 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-@use '~@mozilla-protocol/core/protocol/css/includes/lib';
+@import '~@mozilla-protocol/core/protocol/css/includes/lib';
 @import '~@mozilla-protocol/core/protocol/css/templates/multi-column';
+
+.bb-column-block {
+
+    h2 {
+        @include text-title-xs;
+    }
+
+    .mzp-l-columns {
+        padding-top: 0;
+    }
+}


### PR DESCRIPTION
* Support customisable max-width on section headers, drawn from the page layout class
* Update column block layout: full-bleed light/dark theme; smaller h2 sizing
* Remove excessive padding on hero content
* Adapt Hero heading sizes to match future.m.o - we may or may not keep this for core Birdbox - TBC