### PR TITLE
Fix helper that checks if a H1 should be rendered from a Block, not the page title

### DIFF
--- a/birdbox/microsite/templatetags/microsite_tags.py
+++ b/birdbox/microsite/templatetags/microsite_tags.py
@@ -13,7 +13,7 @@ from wagtail.models import Site
 
 from common.utils import find_streamfield_blocks_by_types, get_freshest_newsletter_data
 
-from ..blocks import ArticleBlock, HeroBlock
+from ..blocks import HeroBlock
 from ..models import Footer, FormStandardMessages, MicrositeSettings, Page
 
 register = Library()
@@ -184,7 +184,10 @@ def seek_dark_theme_class(parent_class_string: str) -> str:
 def block_with_h1_exists_in_page(page: Page) -> bool:
     candidate_blocks = find_streamfield_blocks_by_types(
         page=page,
-        target_block_types=(HeroBlock, ArticleBlock),
+        target_block_types=(
+            HeroBlock,
+            # ArticleBlock does NOT contain a H1 any more, it's a H2
+        ),
     )
     # If we have more than one candidate block in a page, that's a separate problem
     # but should be caught by Wagtail's own a11y checks

--- a/birdbox/microsite/templatetags/microsite_tags.py
+++ b/birdbox/microsite/templatetags/microsite_tags.py
@@ -18,8 +18,15 @@ from ..models import Footer, FormStandardMessages, MicrositeSettings, Page
 
 register = Library()
 
-# Use mozilla-django-product-details to get a set of localised language names
-LANGUAGE_LOOKUP = {k: v.get("native", k) for k, v in product_details.languages.items()}
+_LANGUAGE_LOOKUP = {}
+
+
+def _get_language_lookup():
+    global _LANGUAGE_LOOKUP
+    if not _LANGUAGE_LOOKUP:
+        # Use mozilla-django-product-details to get a set of localised language names
+        _LANGUAGE_LOOKUP = {k: v.get("native", k) for k, v in product_details.languages.items()}
+    return _LANGUAGE_LOOKUP
 
 
 @register.inclusion_tag("microsite/partials/nav.html", takes_context=True)
@@ -107,7 +114,7 @@ def _get_language_name_for_locale(locale_code):
         "en": "en-US",
         "pt": "pt-PT",
     }.get(locale_code, locale_code)
-    return LANGUAGE_LOOKUP.get(adjusted_locale_code, locale_code)
+    return _get_language_lookup().get(adjusted_locale_code, locale_code)
 
 
 @register.inclusion_tag("microsite/blocks/partials/_newsletter_fieldsets.html", takes_context=True)

--- a/birdbox/microsite/tests/test_microsite_tags.py
+++ b/birdbox/microsite/tests/test_microsite_tags.py
@@ -1,0 +1,29 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+from unittest import mock
+
+import pytest
+
+from microsite.templatetags.microsite_tags import block_with_h1_exists_in_page
+
+
+@mock.patch("microsite.templatetags.microsite_tags.find_streamfield_blocks_by_types")
+@pytest.mark.django_db
+@pytest.mark.parametrize(
+    "mocked_helper_retval, expected",
+    (
+        ([], False),
+        (["anything"], True),
+        (["anything", "more-than-one-is-unexpected-but-truthy"], True),
+    ),
+)
+def test_block_with_h1_exists_in_page(
+    mock_find_streamfield_blocks_by_types,
+    mocked_helper_retval,
+    expected,
+):
+    mock_page = mock.Mock()
+    mock_find_streamfield_blocks_by_types.return_value = mocked_helper_retval
+    assert block_with_h1_exists_in_page(mock_page) == expected


### PR DESCRIPTION
This was still treating an ArticleBlock as one which contains a H1 - it now just has a H2