### PR TITLE
Add a custom CSRF failure template, explaining SSO-related resets etc

### DIFF
--- a/birdbox/birdbox/settings/base.py
+++ b/birdbox/birdbox/settings/base.py
@@ -450,6 +450,9 @@ SECURE_HSTS_SECONDS = config("SECURE_HSTS_SECONDS", default="0", parser=int)
 SECURE_HSTS_INCLUDE_SUBDOMAINS = False
 
 
+# Custom CSRF failure view to show custom CSRF messaging
+CSRF_FAILURE_VIEW = "common.views.csrf_failure"
+
 # Authentication with Mozilla OpenID Connect / Auth0
 
 LOGIN_ERROR_URL = "/admin/"

--- a/birdbox/birdbox/templates/403_csrf.html
+++ b/birdbox/birdbox/templates/403_csrf.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en" dir="ltr">
+  <head>
+    <meta charset="utf-8" />
+    <title>CSRF mismatch detected.</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <style type="text/css">
+      body {
+        color: #000;
+        background-color: #fff;
+        font: 100%/1.5 sans-serif;
+        padding: 40px;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Access denied</h1>
+    <p>
+      Cross-site request forgery (CSRF) mismatch detected.
+    </p>
+    {% if request.user.is_staff %}
+    <p>
+      This is most likely because your SSO session expired or had to be renewed.
+    </p>
+    <p>
+      It's likely and regrettable that you have lost work since your last save.
+      <br>
+      If this is happening a lot, please <a href="https://github.com/mozmeao/birdbox/issues">open a bug report</a>.
+    </p>
+    {% endif %}
+    <p>
+      Please go back using your browser's back button and try again. Reloading this page will not fix the problem.
+    </p>
+    </body>
+</html>
+
+

--- a/birdbox/birdbox/urls.py
+++ b/birdbox/birdbox/urls.py
@@ -18,7 +18,7 @@ from wagtail.admin import urls as wagtailadmin_urls
 from wagtail.documents import urls as wagtaildocs_urls
 from watchman import views as watchman_views
 
-from common.views import rate_limited
+from common.views import csrf_failure, rate_limited
 from microsite import urls as microsite_urls
 
 handler500 = "common.views.server_error_view"
@@ -66,6 +66,7 @@ if settings.DEBUG:
     urlpatterns += (
         path("404/", import_string(handler404)),
         path("403/", permission_denied, {"exception": HttpResponseForbidden()}),
+        path("csrf_403/", csrf_failure, {}),
         path("429/", rate_limited, {"exception": Ratelimited()}),
         path("500/", import_string(handler500)),
     )

--- a/birdbox/common/tests/test_views.py
+++ b/birdbox/common/tests/test_views.py
@@ -2,6 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+from django.conf import settings
 from django.test import override_settings
 from django.urls import path, reverse
 
@@ -41,3 +42,8 @@ def test_robots_txt(client, engage_robots, expected_content):
     with override_settings(ENGAGE_ROBOTS=engage_robots):
         resp = client.get("/robots.txt")
         assert resp.content == expected_content
+
+
+@pytest.mark.django_db
+def test_csrf_view_is_custom_one():
+    assert settings.CSRF_FAILURE_VIEW == "common.views.csrf_failure"

--- a/birdbox/common/views.py
+++ b/birdbox/common/views.py
@@ -16,6 +16,10 @@ def page_not_found_view(request, exception=None, template_name="404.html"):
     return render(request, template_name, status=404)
 
 
+def csrf_failure(request, reason="CSRF failure", template_name="403_csrf.html"):
+    return render(request, template_name, status=403)
+
+
 @never_cache
 def rate_limited(request, exception):
     """Render a rate-limited exception page"""


### PR DESCRIPTION
Because a renewed/cycled OIDC/SSO session can zap a CSRF token and block a user from submitting a CMS edit, we need to provide a bit more information about what's happened. This PR adds that, via a new template and a tiny view to serve it, plugged in as Django's default CSRF view

Logged out users (who are very unlikely to see this anyway) get a simple version:
<img width="906" alt="Screenshot 2023-10-09 at 15 34 10" src="https://github.com/mozmeao/birdbox/assets/101457/76771070-3f4a-41ba-ac56-a9fd7bc8907c">


Logged in, staff/CMS users get a bit more context:

<img width="857" alt="Screenshot 2023-10-09 at 15 34 18" src="https://github.com/mozmeao/birdbox/assets/101457/5630a193-62e5-4fb4-9b0b-85ef6dbab815">


To test locally:

* With `DEBUG=True` in your `.env`, go to http://localhost:8000/csrf_403/ in a private window to get the simple version.
* Do the same in a tab where you're signed-in as a CMS user to get the fuller version

Resolves #125 