### PR TITLE
Blog visibility adjustments

### DIFF
--- a/birdbox/microsite/models.py
+++ b/birdbox/microsite/models.py
@@ -921,10 +921,14 @@ class BlogIndexPage(BaseProtocolPage):
         context = super().get_context(request, *args, **kwargs)
 
         # add featured post to the context:
-        context["featured_post"] = self.get_specific_featured_post()
+        context["featured_post"] = self.get_specific_featured_post(
+            is_preview_mode=request.is_preview,
+        )
 
         # now paginate the rest
-        non_featured_posts = self.get_non_featured_ordered_posts()
+        non_featured_posts = self.get_non_featured_ordered_posts(
+            is_preview_mode=request.is_preview,
+        )
         paginator = Paginator(non_featured_posts, settings.BLOG_PAGINATION_PAGE_SIZE)
         page = request.GET.get("page")
         try:
@@ -937,18 +941,27 @@ class BlogIndexPage(BaseProtocolPage):
         context["non_featured_posts"] = posts
         return context
 
-    def get_non_featured_ordered_posts(self, exclude_featured_post=True, live=True):
+    def get_non_featured_ordered_posts(
+        self,
+        exclude_featured_post=True,
+        is_preview_mode=False,
+    ):
         posts = BlogPage.objects.child_of(self).specific().order_by("-date")
-        if live:
+        if not is_preview_mode:
+            # We only want live posts
             posts = posts.live()
         if exclude_featured_post:
-            if featured_post := self.get_specific_featured_post():
+            if featured_post := self.get_specific_featured_post(is_preview_mode=is_preview_mode):
                 posts = posts.exclude(id=featured_post.id)
         return posts
 
-    def get_specific_featured_post(self, live=True) -> List[BlogPage]:
+    def get_specific_featured_post(
+        self,
+        is_preview_mode=False,
+    ) -> List[BlogPage]:
         base_qs = BlogPage.objects.child_of(self).specific().order_by("-date")
-        if live:
+        if not is_preview_mode:
+            # We only want live posts
             base_qs = base_qs.live()
         return base_qs.filter(is_featured=True).first()
 

--- a/birdbox/microsite/models.py
+++ b/birdbox/microsite/models.py
@@ -937,15 +937,19 @@ class BlogIndexPage(BaseProtocolPage):
         context["non_featured_posts"] = posts
         return context
 
-    def get_non_featured_ordered_posts(self, exclude_featured_post=True):
+    def get_non_featured_ordered_posts(self, exclude_featured_post=True, live=True):
         posts = BlogPage.objects.child_of(self).specific().order_by("-date")
+        if live:
+            posts = posts.live()
         if exclude_featured_post:
             if featured_post := self.get_specific_featured_post():
                 posts = posts.exclude(id=featured_post.id)
         return posts
 
-    def get_specific_featured_post(self) -> List[BlogPage]:
-        base_qs = BlogPage.objects.child_of(self).live().order_by("-date")
+    def get_specific_featured_post(self, live=True) -> List[BlogPage]:
+        base_qs = BlogPage.objects.child_of(self).specific().order_by("-date")
+        if live:
+            base_qs = base_qs.live()
         return base_qs.filter(is_featured=True).first()
 
 

--- a/birdbox/microsite/tests/factories.py
+++ b/birdbox/microsite/tests/factories.py
@@ -2,6 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+import factory
 import wagtail_factories
 
 from microsite import models
@@ -9,6 +10,25 @@ from microsite import models
 
 class HomePageFactory(wagtail_factories.PageFactory):
     title = "Test Home Page"
+    live = True
+    slug = "homepage"
 
     class Meta:
         model = models.HomePage
+
+
+class BlogIndexPageFactory(wagtail_factories.PageFactory):
+    title = "Blog Index"
+    live = True
+
+    class Meta:
+        model = models.BlogIndexPage
+
+
+class BlogPageFactory(wagtail_factories.PageFactory):
+    feed_image = factory.SubFactory(
+        wagtail_factories.ImageChooserBlockFactory,
+    )
+
+    class Meta:
+        model = models.BlogPage

--- a/birdbox/microsite/tests/test_models__blog.py
+++ b/birdbox/microsite/tests/test_models__blog.py
@@ -1,0 +1,79 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+
+from django.test import RequestFactory
+
+import pytest
+
+from microsite.models import BlogIndexPage, BlogPage
+
+# Wondering where some of these arguments are coming from, they may be
+# pytest fixtures declared in conftest.py
+
+
+@pytest.mark.django_db
+def test_live_vs_draft_blog_post_visibility__live_view(
+    client,
+    minimal_site_with_blog,
+):
+    index = BlogIndexPage.objects.get()
+
+    bp1, bp2_featured, bp3 = BlogPage.objects.live().all()
+
+    # Fake a request for live/non-preview viewing
+    request = RequestFactory().get("/blog-index/")
+    request.is_preview = False
+
+    # 1. Show that all three are visible and in results
+    context = index.get_context(request)
+    assert context["featured_post"] == bp2_featured
+    assert [x for x in context["non_featured_posts"]] == [bp3, bp1]
+
+    # 2. Make the featured one draft
+    bp2_featured.unpublish()
+    bp2_featured.save()
+    context = index.get_context(request)
+    assert context["featured_post"] is None
+    assert [x for x in context["non_featured_posts"]] == [bp3, bp1]
+
+    # 3. Make a different one draft
+    bp1.unpublish()
+    bp1.save()
+    context = index.get_context(request)
+    assert context["featured_post"] is None
+    assert [x for x in context["non_featured_posts"]] == [bp3]
+
+
+@pytest.mark.django_db
+def test_live_vs_draft_blog_post_visibility__draft_view(
+    client,
+    minimal_site_with_blog,
+):
+    index = BlogIndexPage.objects.get()
+
+    bp1, bp2_featured, bp3 = BlogPage.objects.live().all()
+
+    # Fake a request for PREVIEW viewing
+    request = RequestFactory().get("/blog-index/")
+    request.is_preview = True
+
+    # 1. Show that all three are visible and in results
+    context = index.get_context(request)
+    assert context["featured_post"] == bp2_featured
+    assert [x for x in context["non_featured_posts"]] == [bp3, bp1]
+
+    # 2. Make the featured one draft - should remain visible
+    bp2_featured.unpublish()
+    bp2_featured.save()
+    context = index.get_context(request)
+    assert context["featured_post"] == bp2_featured
+    assert [x for x in context["non_featured_posts"]] == [bp3, bp1]
+
+    # 3. Make a different one draft - still should be visible
+    bp1.unpublish()
+    bp1.save()
+    context = index.get_context(request)
+    assert context["featured_post"] == bp2_featured
+    assert [x for x in context["non_featured_posts"]] == [bp3, bp1]

--- a/conftest.py
+++ b/conftest.py
@@ -2,10 +2,13 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
+from datetime import date
+
 import pytest
 import wagtail_factories
 
-from microsite.tests.factories import HomePageFactory
+from microsite.models import HomePage
+from microsite.tests.factories import BlogIndexPageFactory, BlogPageFactory, HomePageFactory
 
 
 @pytest.fixture
@@ -19,4 +22,35 @@ def bootstrap_minimal_site(
     return wagtail_factories.SiteFactory(
         root_page=homepage,
         hostname=client._base_environ()["SERVER_NAME"],
+    )
+
+
+@pytest.fixture
+def homepage(bootstrap_minimal_site):
+    return HomePage.objects.get()
+
+
+@pytest.fixture
+def minimal_site_with_blog(bootstrap_minimal_site):
+    homepage = HomePage.objects.get()
+
+    blog_index = BlogIndexPageFactory(
+        parent=homepage,
+    )
+
+    BlogPageFactory(
+        parent=blog_index,
+        title="blog post 1",
+        date=date(2023, 5, 1),
+    )
+    BlogPageFactory(
+        parent=blog_index,
+        title="blog post 2 (featured)",
+        date=date(2023, 5, 11),
+        is_featured=True,
+    )
+    BlogPageFactory(
+        parent=blog_index,
+        title="blog post 3",
+        date=date(2023, 6, 12),
     )


### PR DESCRIPTION
This changeset improves the editor experience for the blog index page when dealing with draft blog posts. It also fixes a bug where a live index page would show a draft post, which was definitely unintended behaviour.

Now: 

* When a user (of any kind) views a published blog index page, only similarly published/live blog posts will be shown.

* If the user is an editor and viewing a PREVIEW of the blog index page, that preview will now include draft blog posts, too.

Resolves #137 