### PR TITLE
Update settings so that SSL upgrade is not done, because it happens at the CDN/LB

### DIFF
--- a/birdbox/.env-example
+++ b/birdbox/.env-example
@@ -1,5 +1,5 @@
 DEBUG=False
-DISABLE_SSL=True
+USE_SECURE_PROXY_HEADER=False
 RATELIMIT_ENABLE=False
 
 EMAIL_BACKEND="django.core.mail.backends.console.EmailBackend"

--- a/birdbox/birdbox/settings/base.py
+++ b/birdbox/birdbox/settings/base.py
@@ -424,14 +424,16 @@ WATCHMAN_CHECKS = (
 
 # Security settings (see `manage.py check --deploy`)
 
-DISABLE_SSL = config("DISABLE_SSL", default=str(DEBUG), parser=bool)  # so default: "False"
 SECURE_SSL_REDIRECT = config(
     "SECURE_SSL_REDIRECT",
-    default=str(not DISABLE_SSL),
+    default="False",  # Deliberately off by default - we don't need to upgrade at the app level
     parser=bool,
-)  # so default: "True"
-if config("USE_SECURE_PROXY_HEADER", default=str(SECURE_SSL_REDIRECT), parser=bool):
+)
+if config("USE_SECURE_PROXY_HEADER", default="True", parser=bool):
     SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
+
+# Only necessary if SECURE_SSL_REDIRECT is set to True at the app level, which we shouldn't
+# need anyway
 SECURE_REDIRECT_EXEMPT = [
     r"^healthz/$",
     r"^readiness/$",

--- a/birdbox/birdbox/settings/base.py
+++ b/birdbox/birdbox/settings/base.py
@@ -429,7 +429,7 @@ SECURE_SSL_REDIRECT = config(
     default="False",  # Deliberately off by default - we don't need to upgrade at the app level
     parser=bool,
 )
-if config("USE_SECURE_PROXY_HEADER", default="True", parser=bool):
+if config("USE_SECURE_PROXY_HEADER", default="False", parser=bool):
     SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 
 # Only necessary if SECURE_SSL_REDIRECT is set to True at the app level, which we shouldn't

--- a/birdbox/birdbox/settings/test.py
+++ b/birdbox/birdbox/settings/test.py
@@ -5,5 +5,4 @@
 from .development import *
 
 DEBUG = False
-DISABLE_SSL = True
-SECURE_SSL_REDIRECT = False
+USE_SECURE_PROXY_HEADER = False

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -94,11 +94,11 @@ services:
     environment:
       ALLOWED_HOSTS: "*"
       CSRF_TRUSTED_ORIGINS: "*"
-      DISABLE_SSL: True
       DATABASE_URL: postgres://postgres:postgres@db/postgres
       EMAIL_BACKEND: "django.core.mail.backends.console.EmailBackend"
       REDIS_URL: redis://redis:6379
       SECRET_KEY: "This is not the 53cr3t k3Y, it is just a tribute"
+      USE_SECURE_PROXY_HEADER: False
 
     image: mozmeao/birdbox:${GIT_COMMIT:-latest}
     platform: linux/amd64

--- a/docker/envfiles/local.env.example
+++ b/docker/envfiles/local.env.example
@@ -1,5 +1,5 @@
 DEBUG=False
-DISABLE_SSL=True
+USE_SECURE_PROXY_HEADER=False
 RATELIMIT_ENABLE=False
 
 EMAIL_BACKEND="django.core.mail.backends.console.EmailBackend"


### PR DESCRIPTION
The CDN redirects non-https to https, so we don't need to do it in the app.

This approach means we avoid risk of a cache-poisoning attack for that http->https upgrade.

Resolves #143 