### PR TITLE
Add cache-control headers to uploaded media

### DIFF
--- a/birdbox/birdbox/settings/base.py
+++ b/birdbox/birdbox/settings/base.py
@@ -159,6 +159,11 @@ else:
 
 GS_BUCKET_NAME = config("GS_BUCKET_NAME", default="", parser=str)
 GS_PROJECT_ID = config("GS_PROJECT_ID", default="", parser=str)
+GS_OBJECT_PARAMETERS = {
+    "cache_control": "max-age=2592000, public, immutable",
+    # 2592000 == 30 days 1 month age
+}
+
 
 if GS_BUCKET_NAME and GS_PROJECT_ID:
     DEFAULT_FILE_STORAGE = "storages.backends.gcloud.GoogleCloudStorage"


### PR DESCRIPTION
This changset ensures we set a Cache-control header for all images uploaded to Google Cloud Storage from Wagtail

As an example, view the Cache-Control headers via the network tab for

* The original image https://storage.googleapis.com/birdbox-sj/images/hills_Xego3mm.original.jpg
* An auto-generated rendtition, which also gets the header https://storage.googleapis.com/birdbox-sj/images/hills_Xego3mm.max-800x600.jpg

Resolves #150 