### PR TITLE
Future.m.o. Contact form validation update

### DIFF
--- a/birdbox/microsite/templates/microsite/blocks/futuremo_contact_form.html
+++ b/birdbox/microsite/templates/microsite/blocks/futuremo_contact_form.html
@@ -46,6 +46,9 @@
               <li class="error-email-invalid hidden">
                   {{form_standard_messages.form_error_email_invalid}}
               </li>
+              <li class="error-name-required hidden">
+                Please provide your name
+              </li>
               <li class="error-select-country hidden">
                   {{form_standard_messages.form_error_select_country}}
               </li>

--- a/src/js/contact/form-utils.js
+++ b/src/js/contact/form-utils.js
@@ -8,6 +8,7 @@ const errorList = {
     EMAIL_INVALID_ERROR: "Invalid email address",
     EMAIL_UNKNOWN_ERROR: "Email address not known",
     NEWSLETTER_ERROR: "Newsletter not selected",
+    NAME_REQUIRED: "Name not provided",
     COUNTRY_ERROR: "Country not selected",
     LANGUAGE_ERROR: "Language not selected",
     PRIVACY_POLICY_ERROR: "Privacy policy not checked",

--- a/src/js/contact/futuremo-contact-form.js
+++ b/src/js/contact/futuremo-contact-form.js
@@ -37,6 +37,9 @@ const EmailForm = {
             case errorList.NEWSLETTER_ERROR:
                 error = form.querySelector(".error-newsletter-checkbox");
                 break;
+            case errorList.NAME_REQUIRED:
+                error = form.querySelector(".error-name-required");
+                break;
             default:
                 error = form.querySelector(".error-try-again-later");
         }
@@ -57,6 +60,7 @@ const EmailForm = {
 
     validateFields: () => {
         const email = form.querySelector('input[type="email"]').value;
+        const name = form.querySelector('input[id="name"]').value;
         const privacy = !!form.querySelector('input[name="privacy"]:checked');
         const newsletters = form.querySelectorAll(
             'input[name="interests"]:checked'
@@ -73,6 +77,13 @@ const EmailForm = {
             EmailForm.handleFormError(errorList.PRIVACY_POLICY_ERROR);
             return false;
         }
+
+        // Confirm name is required on MIECO page
+        if (!name && isMIECO) {
+            EmailForm.handleFormError(errorList.NAME_REQUIRED);
+            return false;
+        }
+
         // the form on the builder page already includes a newsletter so these aren't required
         if (newsletters.length === 0 && !isBuilderPage) {
             EmailForm.handleFormError(errorList.NEWSLETTER_ERROR);


### PR DESCRIPTION
The name field is required on the backend, so make sure the field shows an error in the FE.

The name required string is not editable via the CMS but we can deal with this at a later point, if need be. (Plus the name field doesn't appear in regular newsletter form fields, so other uses of Birdbox won't need it)