### PR TITLE
Add CSP rules

### DIFF
--- a/birdbox/.env-example
+++ b/birdbox/.env-example
@@ -19,3 +19,6 @@ USE_SSO_AUTH=False  # By default for local running, go with username+password au
 OIDC_RP_CLIENT_ID=setme
 OIDC_RP_CLIENT_SECRET=setme
 
+# By default, let's assume CSP locally so we don't get caught out later
+CSP_ENABLED=True
+# Also see base.py for other CSP settings

--- a/birdbox/birdbox/settings/base.py
+++ b/birdbox/birdbox/settings/base.py
@@ -576,6 +576,47 @@ WAGTAILMARKDOWN = {
 }
 
 
+# Content Security Policy settings via django-csp
+# http://django-csp.readthedocs.io/en/latest/configuration.html
+
+CSP_ENABLED = config("CSP_ENABLED", default="False", parser=bool)
+
+_CSP_SELF_ONLY = "'self'"
+
+if CSP_ENABLED:
+    MIDDLEWARE.append("csp.middleware.CSPMiddleware")
+    CSP_EXCLUDE_URL_PREFIXES = (
+        # Until https://github.com/wagtail/wagtail/issues/1288 is resolved, exclude the Wagtail admin
+        "/admin/",
+    )
+
+    CSP_REPORT_ONLY = config("CSP_REPORT_ONLY", default="True", parser=bool)
+    CSP_REPORT_URI = config("CSP_REPORTING_ENDPOINT", default="", parser=str)
+
+    # Remember to quote 'self', 'unsafe-inline', 'unsafe-eval', or 'none'
+    # e.g.: CSP_DEFAULT_SRC = "'self'" - without quotes they will not work as intended.
+
+    CSP_DEFAULT_SRC = config("CSP_DEFAULT_SRC", default=_CSP_SELF_ONLY, parser=str)
+
+    CSP_SCRIPT_SRC = config("CSP_SCRIPT_SRC", default=_CSP_SELF_ONLY, parser=str)
+    CSP_STYLE_SRC = config("CSP_STYLE_SRC", default="'self' 'unsafe-inline'", parser=str)
+
+    # CSP_IMG_SRC will be set in production with details of the relevant cloud bucket
+    CSP_IMG_SRC = config("CSP_IMG_SRC", default="'self' data:", parser=str)
+    CSP_FONT_SRC = config("CSP_FONT_SRC", default=_CSP_SELF_ONLY, parser=str)
+
+    CSP_CONNECT_SRC = config("CSP_CONNECT_SRC", default=_CSP_SELF_ONLY, parser=str)
+    CSP_BASE_URI = config(
+        "CSP_BASE_URI",
+        default="'none'",  # https://csp.withgoogle.com/docs/strict-csp.html
+        parser=str,
+    )
+    CSP_OBJECT_SRC = config(
+        "CSP_OBJECT_SRC",
+        default="'none'",  # Deny by default - https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/object-src
+        parser=str,
+    )
+
 # Mozillaverse settings
 
 BASKET_SUBSCRIPTION_URL = config(

--- a/docker/envfiles/local.env.example
+++ b/docker/envfiles/local.env.example
@@ -19,3 +19,6 @@ USE_SSO_AUTH=False  # By default for local running, go with username+password au
 OIDC_RP_CLIENT_ID=setme
 OIDC_RP_CLIENT_SECRET=setme
 
+# By default, let's assume CSP locally so we don't get caught out later
+CSP_ENABLED=True
+# Also see base.py for other CSP settings

--- a/requirements/production.in
+++ b/requirements/production.in
@@ -1,9 +1,10 @@
 certifi>=2023.7.22
 cryptography>=41.0.4
 dj-database-url==2.1.0
+Django>=4.2.5
+django-csp==3.7
 django-mozilla-product-details>=1.0.3
 django-storages[google]==1.14.2
-Django>=4.2.5
 django-ratelimit==4.1.0
 django-redis==5.4.0
 django-jsonview==2.0.0

--- a/requirements/production.txt
+++ b/requirements/production.txt
@@ -217,6 +217,7 @@ django==4.2.5 \
     # via
     #   -r requirements/production.in
     #   dj-database-url
+    #   django-csp
     #   django-filter
     #   django-modelcluster
     #   django-mozilla-product-details
@@ -229,6 +230,10 @@ django==4.2.5 \
     #   djangorestframework
     #   mozilla-django-oidc
     #   wagtail
+django-csp==3.7 \
+    --hash=sha256:01443a07723f9a479d498bd7bb63571aaa771e690f64bde515db6cdb76e8041a \
+    --hash=sha256:01eda02ad3f10261c74131cdc0b5a6a62b7c7ad4fd017fbefb7a14776e0a9727
+    # via -r requirements/production.in
 django-filter==22.1 \
     --hash=sha256:ed429e34760127e3520a67f415bec4c905d4649fbe45d0d6da37e6ff5e0287eb \
     --hash=sha256:ed473b76e84f7e83b2511bb2050c3efb36d135207d0128dfe3ae4b36e3594ba5


### PR DESCRIPTION
This changeset adds CSP support by using django-csp and a set of defaults that work with the current Birdbox setup.

The Wagtail admin is not in scope for the rules, because it may and does break with the main-site rules applied.

Enabling CSP and tweaking its config is done via env vars. Initially we'll run it only on Dev and when we move it to stage and prod we'll start in report-only mode. Reports go to Sentry for now

Needs https://github.com/mozilla-it/webservices-infra/pull/1200 to be merged first