### PR TITLE
Support an allowlist of page types that may be added to a site

### DIFF
--- a/birdbox/birdbox/settings/base.py
+++ b/birdbox/birdbox/settings/base.py
@@ -16,7 +16,7 @@ from django.utils.log import DEFAULT_LOGGING
 
 import dj_database_url
 import sentry_sdk
-from everett.manager import ConfigEnvFileEnv, ConfigManager, ConfigOSEnv
+from everett.manager import ConfigEnvFileEnv, ConfigManager, ConfigOSEnv, ListOf
 from sentry_sdk.integrations.django import DjangoIntegration
 from sentry_sdk.integrations.logging import ignore_logger
 from wagtail.embeds.oembed_providers import vimeo, youtube
@@ -528,6 +528,14 @@ DEFAULT_LOGGING["loggers"]["mozilla_django_oidc"] = {
     "level": "INFO",
 }
 
+# Custom code in birdbox.microsite.models.BirdboxBasePage limits what page models
+# can be added - allowing us to configure deployments of Birdbox to behave
+# differently while still all sharing the same common codebase.
+ALLOWED_PAGE_MODELS = config(
+    "ALLOWED_PAGE_MODELS",
+    default="__all__",
+    parser=ListOf(str),
+)
 
 WAGTAILMARKDOWN = {
     "autodownload_fontawesome": False,

--- a/birdbox/microsite/models.py
+++ b/birdbox/microsite/models.py
@@ -62,6 +62,8 @@ from .blocks import (
     VideoEmbedBlock,
 )
 
+ALL = "__all__"
+
 
 class ProtocolLayout(TextChoices):
     SMALL = "mzp-l-content mzp-t-content-sm", "Small"
@@ -158,6 +160,15 @@ class BaseProtocolPage(CacheAwareAbstractBasePage):
     def get_children_for_nav(self):
         "Only return children that may be shown in a nav menu"
         return self.get_children().specific().filter(show_in_menus=True)
+
+    @classmethod
+    def can_create_at(cls, parent):
+        """Only allow users to create pages that are permitted
+        by configuration."""
+        page_model_signature = f"{cls._meta.app_label}.{cls._meta.object_name}"
+        if settings.ALLOWED_PAGE_MODELS == [ALL] or page_model_signature in settings.ALLOWED_PAGE_MODELS:
+            return super().can_create_at(parent)
+        return False
 
 
 class StructuralPage(BaseProtocolPage):


### PR DESCRIPTION
Because we'll be using forks of mozmeao/birdbox for multiple sites over time we are likely to end up with additional Page models which are relevant to only one (or a few) websites.

This changeset adds support for allowlist of `app_name.PageModelName` specs for which page types are allowed to be added. By default, all page types are allowed.

Resolves #213

----

Default settings mean all page types are available:

<img width="1016" alt="Screenshot 2023-11-29 at 13 35 16" src="https://github.com/mozmeao/birdbox/assets/101457/8e140038-aa4f-46b5-bd98-d07254784384">



with `ALLOWED_PAGE_MODELS = "microsite.StructuralPage,microsite.GeneralPurposePage"` in my `.env`:

<img width="1002" alt="Screenshot 2023-11-29 at 13 34 13" src="https://github.com/mozmeao/birdbox/assets/101457/ebb28aae-7e74-4cbc-8922-61e5eb4a567e">

