### PR TITLE
Add Protocol article styles, with centered title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-No changes
+### Changed
+
+* Add Protocol article styling for article blocks, including a class for centered titles.
 
 ## [1.3.0]
 

--- a/birdbox/microsite/blocks.py
+++ b/birdbox/microsite/blocks.py
@@ -553,7 +553,7 @@ class ArticleBlock(wagtail_blocks.StructBlock):
     def frontend_media(self):
         "Custom property that lets us selectively include CSS"
         return forms.Media(
-            css={"all": [static("css/birdbox-article.css")]},
+            css={"all": [static("css/protocol-article.css")]},
         )
 
     title = wagtail_blocks.CharBlock(

--- a/src/css/protocol/components/article.scss
+++ b/src/css/protocol/components/article.scss
@@ -4,3 +4,13 @@
 
 @use '~@mozilla-protocol/core/protocol/css/includes/lib' as * with ($image-path: '/static/protocol/img');
 @import '~@mozilla-protocol/core/protocol/css/components/article';
+
+.mzp-c-article {
+    margin: 0 auto;
+    max-width: $content-lg;
+    width: auto;
+
+    .t-align-center {
+        text-align: center;
+    }
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -45,6 +45,7 @@ module.exports = {
         "protocol-section-heading":
             "./src/css/protocol/components/section-heading.scss",
         "protocol-breadcrumb": "./src/css/protocol/components/breadcrumb.scss",
+        "protocol-article": "./src/css/protocol/components/article.scss",
 
         // custom CSS
         "birdbox-navigation": "./src/css/navigation.scss",


### PR DESCRIPTION
## Description

Looks like we weren't loading any of the article component styles for article blocks, and were loading the blog post styles instead... none of which were being applied anyway because they all hang from a different class. This adds a separate Protocol article style for regular (non-blog) article blocks, and also includes the class for centered titles. 

It overrides a few aspects of the original component (the width and margins), but the component is slated for some changes in upstream Protocol soonish anyway. 

- [ ] I have manually tested this.
- [ ] I have recorded this change in `CHANGELOG.md`.

### Testing
Within an article block, set the title alignment option to "Centered" (which is the default already), then ensure that the rendered page has a title that is indeed center aligned.

Loading the article component styles should now also make an article intro block a slightly larger font-size than the rest of the article. This wasn't working previously.
