### PR TITLE
Remove analytics from 40x and 50x templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
-No changes
+### Changed
+
+* Do no load analytics JS (if allowed based on DNT) on 40x pages
 
 ## [1.3.0]
 

--- a/birdbox/birdbox/templates/403.html
+++ b/birdbox/birdbox/templates/403.html
@@ -4,6 +4,8 @@
 
 {% block body_class %}template-403{% endblock %}
 
+{% block analytics %}{% endblock analytics %}
+
 {% block content %}
 <div class="mzp-l-content mzp-t-content-lg">
   <h1>Access denied</h1>

--- a/birdbox/birdbox/templates/404.html
+++ b/birdbox/birdbox/templates/404.html
@@ -2,6 +2,8 @@
 
 {% block title %}Page not found{% endblock %}
 
+{% block analytics %}{% endblock analytics %}
+
 {% block body_class %}template-404{% endblock %}
 
 {% block content %}


### PR DESCRIPTION
## Description

Stop loading analytics JS on 403 and 404 pages

- [X] I have manually tested this.
- [X] I have recorded this change in `CHANGELOG.md`.

### Issue

Resolves #261 

### Testing

* Set DEBUG=False in your env
* `npm run build`
* `just collectstatic`
* ./birdbox/manage.py runserver`
* Go to localhost:8000/kjhsdflkahgfl and view source see there is no reference to `/static/js/analytics`.... in the 404 page. Compare with localhost:8000 where it still will mentioned 