### PR TITLE
Allow anchor elements to include common attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Update YouTube video embeds to use the youtube-nocookie.com domain instead of regular youtube.com
 * Do not load analytics JS (if allowed based on DNT) on 40x pages
 * Dependency updates for security and stability
+* Configure wagtail-markdown so that bleach does not strip anchor element attributes.
 
 ## [1.3.0]
 

--- a/birdbox/birdbox/settings/base.py
+++ b/birdbox/birdbox/settings/base.py
@@ -585,7 +585,14 @@ WAGTAILMARKDOWN = {
         "br",
     ],
     "allowed_styles": [],  # a list of CSS attributes - nothing allowed
-    "allowed_attributes": {},  # optional. a dict with HTML tag as key and a list of attributes as value
+    "allowed_attributes": { # optional. a dict with HTML tag as key and a list of attributes as value
+        "a": [
+            "href",
+            "target",
+            "rel",
+            "title",
+        ],
+    },
     "allowed_settings_mode": "override",  # optional. Possible values: "extend" or "override". Defaults to "extend".
     "extensions": [],  # optional. a list of python-markdown supported extensions
     "extension_configs": {},  # optional. a dictionary with the extension name as key, and its configuration as value


### PR DESCRIPTION
## Description

Configure `wagtail-markdown` so that [bleach](https://github.com/mozilla/bleach) does not strip the `href` attribute from markdown links authored in wagtail markdown blocks.

- [x] I have manually tested this.
- [x] I have recorded this change in `CHANGELOG.md`.

### Details

As far as I can tell, `birdbox` overrides the [default configuration](https://github.com/torchbox/wagtail-markdown/blob/5b64706d203536c4eec9352f2f9645d52e9095d6/src/wagtailmarkdown/constants.py#L39-L65) for `wagtail-markdown`:
https://github.com/mozmeao/birdbox/blob/4d8feb970d49c92755d1cebbe5378452803e45ba/birdbox/birdbox/settings/base.py#L596

This `override` setting is used by `wagtail-markdown` [here](https://github.com/torchbox/wagtail-markdown/blob/5b64706d203536c4eec9352f2f9645d52e9095d6/src/wagtailmarkdown/utils.py#L33-L75).

This configuration tells `bleach` to strip the `href` attribute from anchor tags. This breaks content authoring in `wagtail` for any markdown blocks that want to use links (as in the linked issue). 

IF my understanding is correct, it may be worth investigating whether there are any more `allowed_attributes` that should be added to [`WAGTAILMARKDOWN`](https://github.com/mozmeao/birdbox/blob/0cc50659b89535736bc967111a98263638519674/birdbox/birdbox/settings/base.py#L549-L600).

### Issue

https://github.com/mozmeao/birdbox/issues/300

### Testing

I don't know how to test or run `birdbox`, `wagtail`, or `wagtail-markdown`, so I did NOT test this change. (It is just my best guess about what's going wrong based on my rough understanding of the code.) Hopefully it's on the right track but I would need the help of a maintainer to confirm.
