### PR TITLE
Ensure wagtail-markdown can render images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Update YouTube video embeds to use the youtube-nocookie.com domain instead of regular youtube.com
 * Do not load analytics JS (if allowed based on DNT) on 40x pages
 * Dependency updates for security and stability
-* Configure wagtail-markdown so that bleach does not strip anchor element attributes.
+* Configure wagtail-markdown so that bleach does not strip anchor element attributes
+* Configure wagtail-markdown so that bleach does not strip img element attributes
 
 ## [1.3.0]
 

--- a/birdbox/birdbox/settings/base.py
+++ b/birdbox/birdbox/settings/base.py
@@ -585,11 +585,16 @@ WAGTAILMARKDOWN = {
         "br",
     ],
     "allowed_styles": [],  # a list of CSS attributes - nothing allowed
-    "allowed_attributes": { # optional. a dict with HTML tag as key and a list of attributes as value
+    "allowed_attributes": {  # optional. a dict with HTML tag as key and a list of attributes as value
         "a": [
             "href",
             "target",
             "rel",
+            "title",
+        ],
+        "img": [
+            "src",
+            "alt",
             "title",
         ],
     },


### PR DESCRIPTION
## Description

Add missing config to ensure wagtail-markdown can render images

- [X] I have manually tested this.
- [X] I have recorded this change in `CHANGELOG.md`.


