### PR TITLE
Bump rate limit to 300/m

### DIFF
--- a/birdbox/birdbox/settings/base.py
+++ b/birdbox/birdbox/settings/base.py
@@ -420,7 +420,7 @@ RATELIMIT_USE_CACHE = config(
 RATELIMIT_VIEW = "common.views.rate_limited"
 RATELIMIT_DEFAULT_LIMIT = config(
     "RATELIMIT_DEFAULT_LIMIT",
-    default="85/m",
+    default="300/m",
     parser=str,
 )
 


### PR DESCRIPTION
## Description

I'm not sure if I'm doing something wrong, but in the course of a normal attempt to edit a page I am running into the rate limiter.

![image](https://github.com/mozmeao/birdbox/assets/4072106/17f4c26e-afc3-4402-ac17-54fe348b8276)

Initially I copied a blog post that I wrote for another blog with markdown that included a lot of image links that were local to the current page, and I need to rewrite those links to be correct for where wagtail will store those images instead. It may be that loading the page that makes a couple dozen requests (that all fail, because the image links are wrong) is causing me to go above 80.

I plan to fix the issue with my article, because it shouldn't have all those incorrect image links in it... but I wonder if the limit can safely be raised to make this less likely to be a problem for (non-malicious) editors.

- [ ] I have manually tested this.
- [ ] I have recorded this change in `CHANGELOG.md`.

### Issue

Add a link to a related GitHub issue if applicable.

### Testing

Enter helpful notes for whoever code reviews this change.
