### PR TITLE
Fix StructuralPage blow-up when trying to add one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* Fix StructuralPage blow-up when trying to add one (#309)
 * Increase default rate limit to 300reqs/min, up from 85r/min
 
 ## [1.4.0]

--- a/birdbox/microsite/models.py
+++ b/birdbox/microsite/models.py
@@ -188,6 +188,10 @@ class StructuralPage(BaseProtocolPage):
     settings_panels = Page.settings_panels + [
         FieldPanel("show_in_menus"),
     ]
+    content_panels = [
+        FieldPanel("title"),
+        FieldPanel("slug"),
+    ]
     promote_panels = []
 
     def serve_preview(self, request, mode_name="irrelevant"):


### PR DESCRIPTION
## Description

We dropped all the Promote tab panels, but didn't reinstate the slug field anywhere, so it'd 500 when adding a StructuralPage

- [X] I have manually tested this.
- [X] I have recorded this change in `CHANGELOG.md`.

### Issue

Resolves #309

