### PR TITLE
1.7.1 release and bugfix: reveal canonical-url field for BlogPost model, too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,13 +15,23 @@ Nothing yet
 
 Nothing yet
 
-## [1.7.0]
+## [1.7.1]
 
 ### Changed
 
-* Add first cut of Innovation-specific Theme, alongide Mozorg and Firefox themes
+* Bugfix: reveal field in Wagtail UI for managing rel=canonical on BlogPost pages, too
 * Dependency updates
+
+## [1.7.0]
+
+### Added
+
+* Add first cut of Innovation-specific Theme, alongide Mozorg and Firefox themes
 * Support declaring a preferred URL for a page via rel=canonical (#351)
+
+### Changed
+
+* Dependency updates
 
 ## [1.6.1]
 

--- a/birdbox/microsite/models.py
+++ b/birdbox/microsite/models.py
@@ -974,6 +974,7 @@ class BlogPage(BaseProtocolPage):
             "Feed Image",
         ),
         FieldPanel("tags"),
+        FieldPanel("canonical_rel"),
     ]
     Page.settings_panels + [
         show_in_menus_panel,


### PR DESCRIPTION
## Description

reveal canonical-url field for BlogPost model, too

- [X] I have manually tested this.
- [X] I have recorded this change in `CHANGELOG.md`.