### PR TITLE
Update Builders Challenge Form copy

### DIFF
--- a/birdbox/microsite/forms.py
+++ b/birdbox/microsite/forms.py
@@ -101,8 +101,8 @@ class BuildersChallengeForm(ContactFormBase):
         label=("What are you interested in learning more about?"),
         choices=(
             (
-                "mozilla-technology",
-                _("Topics like AI and machine learning, the metaverse, extended reality (XR) and the future of the web."),
+                "mozilla-builders-application-2024",
+                _("Update me about the application process, deadlines, and any changes."),
             ),
         ),
         widget=forms.CheckboxSelectMultiple(),

--- a/birdbox/microsite/forms.py
+++ b/birdbox/microsite/forms.py
@@ -98,13 +98,8 @@ class MEICOContactForm(ContactFormBase):
 
 class BuildersChallengeForm(ContactFormBase):
     interests = forms.MultipleChoiceField(
-        label=("What are you interested in learning more about?"),
-        choices=(
-            (
-                "mozilla-builders-application-2024",
-                _("Update me about the application process, deadlines, and any changes."),
-            ),
-        ),
+        label=(""),
+        choices=(),
         widget=forms.CheckboxSelectMultiple(),
     )
 


### PR DESCRIPTION
## Description

Update the copy of the Mozilla Builders Challenge form.

In https://github.com/mozmeao/birdbox/pull/384/commits/5d71eb769c0cca38168ede2e3aa917713cee6536 I added an option to also sign up for `mozilla-builders-application-2024`, but until that newsletter is created, we shouldn't offer additional options.

- [ ] I have manually tested this.
- [ ] I have recorded this change in `CHANGELOG.md`.

### Issue

Add a link to a related GitHub issue if applicable.

### Testing

Enter helpful notes for whoever code reviews this change.
