### PR TITLE
Restore interests option in the Builder's Challenge form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Nothing yet
 
 ### Changed
 
-Nothing yet
+* Restore interests option in the Builder's Challenge form
 
 ## [1.8.2]
 

--- a/birdbox/microsite/forms.py
+++ b/birdbox/microsite/forms.py
@@ -97,18 +97,18 @@ class MEICOContactForm(ContactFormBase):
 
 
 class BuildersChallengeForm(ContactFormBase):
-    def __init__(self, *args, **kwargs):
-        interests = forms.MultipleChoiceField(
-            label=(""),
-            choices=(
-                (
-                    "mozilla-builders-application-2024",
-                    _("Keep me updated about the application process, deadlines, and any changes."),
-                ),
+    interests = forms.MultipleChoiceField(
+        label=(""),
+        choices=(
+            (
+                "mozilla-builders-application-2024",
+                _("Keep me updated about the application process, deadlines, and any changes."),
             ),
-            widget=forms.CheckboxSelectMultiple(),
-          )
+        ),
+        widget=forms.CheckboxSelectMultiple(),
+    )
 
+    def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
         # no extra fields, just an email field for newsletter signups; no message sending

--- a/birdbox/microsite/forms.py
+++ b/birdbox/microsite/forms.py
@@ -98,6 +98,17 @@ class MEICOContactForm(ContactFormBase):
 
 class BuildersChallengeForm(ContactFormBase):
     def __init__(self, *args, **kwargs):
+        interests = forms.MultipleChoiceField(
+            label=(""),
+            choices=(
+                (
+                    "mozilla-builders-application-2024",
+                    _("Keep me updated about the application process, deadlines, and any changes."),
+                ),
+            ),
+            widget=forms.CheckboxSelectMultiple(),
+          )
+
         super().__init__(*args, **kwargs)
 
         # no extra fields, just an email field for newsletter signups; no message sending

--- a/birdbox/microsite/forms.py
+++ b/birdbox/microsite/forms.py
@@ -98,7 +98,7 @@ class MEICOContactForm(ContactFormBase):
 
 class BuildersChallengeForm(ContactFormBase):
     interests = forms.MultipleChoiceField(
-        label=(""),
+        label=("Do you want additional information beyond the main Challenge updates?"),
         choices=(
             (
                 "mozilla-builders-application-2024",


### PR DESCRIPTION
The `mozilla-builders-application-2024` newsletter has been created so that we can separately send updates about the program and the application process.

## Description

Describe what this change does.

- [ ] I have manually tested this.
- [x] I have recorded this change in `CHANGELOG.md`.

