### PR TITLE
innovation theme, update footer heading color [fix #444]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ Nothing yet
 
 ### Changed
 
+* CSS fix for Innovation theme footer headings (#444)
+
 ## [1.8.6]
 
 * Dependency bump for Django to latest secure version (4.2.15)

--- a/src/css/protocol/innovation.scss
+++ b/src/css/protocol/innovation.scss
@@ -157,6 +157,10 @@ body.brand-theme-innovation {
             }
         }
     }
+
+    .mzp-c-footer .mzp-c-footer-heading {
+        color: $inno-color-highlight-green;
+    }
 }
 
 // override to allow a wordmark to go above without extra spacing on the off-white background


### PR DESCRIPTION
## Description
Adds a CSS rule to override the heading color in the footer for the Innovation theme.

- [x] I have manually tested this.
- [x] I have recorded this change in `CHANGELOG.md`.

### Issue
#444 

### Testing
With the Innovation theme set, scroll to the footer and... look at it.
