### PR TITLE
Add TOC extension for markdown to allow linking to h1–h4 headers

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -11,7 +11,8 @@ GS_PROJECT_ID="gcp-project-name-here"
 GOOGLE_APPLICATION_CREDENTIALS="./local-credentials/add-your-service-account-credentials-here.json"
 
 # SSO / OIDC configuration
-USE_SSO_AUTH=False  # By default for local running, go with username+password auth, not SSO
+# By default for local running, go with username+password auth, not SSO
+USE_SSO_AUTH=False
 
 # If USE_SSO_AUTH is True, you'll be using Mozilla OpenID Connect via Auth0
 # Get from IAM creentials from an appropriate person within the org to set here
@@ -37,5 +38,3 @@ SENTRY_DSN=http://public@127.0.0.1:8015/1
 CSP_REPORTING_ENDPOINT = http://public@127.0.0.1:8015/api/1/security/
 
 # Also see base.py for other CSP settings
-
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-Nothing yet
+* Enabled TOC extension for markdown, allowing headers from h1 to h4 to have ids
+  automatically assigned.
 
 ### Changed
 

--- a/birdbox/birdbox/settings/base.py
+++ b/birdbox/birdbox/settings/base.py
@@ -597,9 +597,16 @@ WAGTAILMARKDOWN = {
             "alt",
             "title",
         ],
+        "h1": ["id"],
+        "h2": ["id"],
+        "h3": ["id"],
+        "h4": ["id"],
     },
     "allowed_settings_mode": "override",  # optional. Possible values: "extend" or "override". Defaults to "extend".
-    "extensions": [],  # optional. a list of python-markdown supported extensions
+    # optional. a list of python-markdown supported extensions
+    "extensions": [
+        "markdown.extensions.toc",
+    ],
     "extension_configs": {},  # optional. a dictionary with the extension name as key, and its configuration as value
     "extensions_settings_mode": "extend",  # optional. Possible values: "extend" or "override". Defaults to "extend".
 }


### PR DESCRIPTION
## Description

This enabled the toc extension for markdown, which automatically assigns IDs to titles (allowing the use of link to anchors). It's also possible to create a toc using the `[TOC]` directive in a markdown block.

- [x] I have manually tested this.
- [x] I have recorded this change in `CHANGELOG.md`.

### Testing

Create a markdown block with titles, try to link from another section, or add a TOC.
